### PR TITLE
Update bootstrap.sh location

### DIFF
--- a/.config/respawn/bootstrap.sh
+++ b/.config/respawn/bootstrap.sh
@@ -41,7 +41,7 @@ install_thing () {
        "Salt")
             # Salt Installation
             echo "Installing Salt. Please provide your root password."
-            curl -o bootstrap-salt.sh -L https://bootstrap.saltproject.io && sudo sh bootstrap-salt.sh
+            curl -o bootstrap-salt.sh -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh && sudo sh bootstrap-salt.sh
             ;;
         "Git")
             # Git Installation


### PR DESCRIPTION
official guide is here --> https://github.com/saltstack/salt-bootstrap/blob/develop/README.rst

The unmodified one liner is

curl -o bootstrap-salt.sh -L https://github.com/saltstack/salt-bootstrap/releases/latest/download/bootstrap-salt.sh sudo sh bootstrap-salt.sh -P stable 3006.1